### PR TITLE
Add lifetime parameter to FrameBuffer

### DIFF
--- a/src/frame_buffer/frame_allocator.rs
+++ b/src/frame_buffer/frame_allocator.rs
@@ -36,7 +36,7 @@ pub trait FrameAllocator {
     ///   assert!(frame_error.is_err());
     /// # }
     /// ```
-    fn get_frame(&self) -> Result<FrameBuffer, Error>;
+    fn get_frame(&self) -> Result<FrameBuffer<'static>, Error>;
 }
 
 #[cfg(test)]

--- a/src/frame_buffer/single_frame_allocator.rs
+++ b/src/frame_buffer/single_frame_allocator.rs
@@ -90,7 +90,7 @@ impl SingleFrameAllocator {
 }
 
 impl FrameAllocator for SingleFrameAllocator {
-    fn get_frame(&self) -> Result<FrameBuffer, Error> {
+    fn get_frame(&self) -> Result<FrameBuffer<'static>, Error> {
         let mut result = Err(Error::WouldBlock);
         SingleFrameAllocator::use_frame_allocator(|fa| {
             result = if fa.is_allocated {

--- a/src/radio.rs
+++ b/src/radio.rs
@@ -54,7 +54,7 @@ pub struct RxOk {
     ///
     /// For IEEE 802.15.4 this buffer contains PHR and PSDU of the received frame, where MFR might
     /// be malformed
-    pub frame: FrameBuffer,
+    pub frame: FrameBuffer<'static>,
 }
 
 // TODO: context parameter?
@@ -64,7 +64,7 @@ pub type RxCallback = fn(Result<RxOk, Error>);
 /// Internal data required in the RX state
 struct RxData {
     callback: RxCallback,
-    rx_buffer: FrameBuffer,
+    rx_buffer: FrameBuffer<'static>,
 }
 
 /// The state of the software PHY FSM
@@ -441,7 +441,7 @@ impl Phy {
     ///   assert_eq!(result, Ok(()));
     /// }
     /// ```
-    pub fn rx(&self, rx_buffer: FrameBuffer, callback: RxCallback) -> Result<(), Error> {
+    pub fn rx(&self, rx_buffer: FrameBuffer<'static>, callback: RxCallback) -> Result<(), Error> {
         if rx_buffer.len() <= 127 {
             // TODO: remove magic number
             return Err(Error::TooSmallBuffer);


### PR DESCRIPTION
FrameBuffer with explicit lifetime makes it possible to create FrameBuffer instances pointing to buffers with shorter lifetime than `static.