### PR TITLE
Fix error code in SingleFrameAllocator

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@
 pub enum Error {
     /// The module is busy with ongoing operation
     WouldBlock,
+    /// Not enough available memory
+    NoMemory,
     /// The passed buffer cannot contain all necessary data
     TooSmallBuffer,
     /// The received frame is invalid


### PR DESCRIPTION
When there was no available frame buffer in the singleFrameAllocator, it reported Error::WouldBlock. Now it correctly reports Error::NoMemory