### PR TITLE
Remove mutable iterator from LinkedList

### DIFF
--- a/src/utils/linked_list.rs
+++ b/src/utils/linked_list.rs
@@ -8,7 +8,7 @@
 //! correct links between the items, but not for the memory management. The implication of such
 //! design is required lifetime of list items, which must be at least as long as the list itself.
 
-use super::linked_list_iter::{Iter, IterMut};
+use super::linked_list_iter::Iter;
 use core::ops::{Deref, DerefMut};
 
 /// Errors reported by the methods in this module
@@ -391,35 +391,6 @@ impl<'list, T> LinkedList<'list, T> {
         Iter::new(self)
     }
 
-    /// Returns an iterator that allows modyfing each item.
-    ///
-    /// The iterator yields all linked items.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use core::ops::Deref;
-    /// use nrf_radio::utils::linked_list::{LinkedList, ListItem};
-    ///
-    /// let mut list = LinkedList::new();
-    /// let mut item1 = ListItem::new(1);
-    /// let mut item2 = ListItem::new(2);
-    ///
-    /// list.push(&mut item1);
-    /// list.push(&mut item2);
-    ///
-    /// for mut item in list.iter_mut() {
-    ///   *item = 3;
-    /// }
-    ///
-    /// while let Some(item) = list.pop() {
-    ///   assert_eq!(**item, 3);
-    /// }
-    /// ```
-    pub fn iter_mut(&mut self) -> IterMut<'_, 'list, T> {
-        IterMut::new(self)
-    }
-
     /// Returns reference to the first item in the list or None if the list is empty.
     ///
     /// This method is intended to be used by an iterator implementation.
@@ -450,15 +421,6 @@ impl<'iter, 'list, T> IntoIterator for &'iter LinkedList<'list, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'iter, 'list, T> IntoIterator for &'iter mut LinkedList<'list, T> {
-    type Item = &'iter mut T;
-    type IntoIter = IterMut<'iter, 'list, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
     }
 }
 
@@ -630,32 +592,6 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut() {
-        let mut list = LinkedList::new();
-        let mut item1 = ListItem::new(1);
-        let mut item2 = ListItem::new(2);
-        let mut item3 = ListItem::new(3);
-
-        list.push(&mut item1);
-        list.push(&mut item2);
-        list.push(&mut item3);
-
-        for item in list.iter_mut() {
-            *item -= 1;
-        }
-
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 2);
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 1);
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 0);
-
-        let item_ref = list.pop();
-        assert!(item_ref.is_none());
-    }
-
-    #[test]
     fn test_into_iter() {
         let mut list = LinkedList::new();
         let mut item1 = ListItem::new(1);
@@ -673,32 +609,6 @@ mod tests {
         }
 
         assert_eq!(cnt, 3);
-    }
-
-    #[test]
-    fn test_into_iter_mutable() {
-        let mut list = LinkedList::new();
-        let mut item1 = ListItem::new(1);
-        let mut item2 = ListItem::new(2);
-        let mut item3 = ListItem::new(3);
-
-        list.push(&mut item1);
-        list.push(&mut item2);
-        list.push(&mut item3);
-
-        for item in &mut list {
-            *item += 1;
-        }
-
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 4);
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 3);
-        let item_ref = list.pop();
-        assert_eq!(**(item_ref.unwrap()), 2);
-
-        let item_ref = list.pop();
-        assert!(item_ref.is_none());
     }
 
     #[test]

--- a/src/utils/linked_list_iter.rs
+++ b/src/utils/linked_list_iter.rs
@@ -31,47 +31,6 @@ impl<'iter, T> Iterator for Iter<'iter, '_, T> {
     }
 }
 
-/*
- * This IterMut was a nice rust learning excercise, but I don't think it should be available for
- * LinkedList. IterMut would allow anyone with access to LinkedList to modify content of items
- * pushed to the list by other users. Only a user owning a token should be allowed to modify it.
- */
-pub struct IterMut<'iter, 'list, T> {
-    next: Option<&'iter mut Option<&'list mut ListItem<'list, T>>>,
-}
-
-impl<'iter, 'list, T> IterMut<'iter, 'list, T> {
-    /// Create new mutable iterator.
-    ///
-    /// This function is to be used by ['LinkedList.iter_mut()'](LinkedList::iter_mut).
-    pub(super) fn new(list: &'iter mut LinkedList<'list, T>) -> Self {
-        Self {
-            next: Some(list.get_mut_first()),
-        }
-    }
-}
-
-impl<'iter, 'list, T> Iterator for IterMut<'iter, 'list, T> {
-    type Item = &'iter mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let tmp: Option<&'iter mut Option<&'list mut ListItem<'list, T>>> = self.next.take();
-        let (next, following): (
-            Option<&'iter mut T>,
-            Option<&'iter mut Option<&'list mut ListItem<'list, T>>>,
-        ) = match tmp {
-            Some(Some(item_ref)) => {
-                let (next, following) = item_ref.get_mut_data_and_next();
-                (Some(next), Some(following))
-            }
-            Some(None) | None => (None, None),
-        };
-
-        self.next = following;
-        next
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,31 +72,5 @@ mod tests {
         }
 
         assert_eq!(cnt, 2);
-    }
-
-    #[test]
-    fn test_create_mut_iterator_in_scope_smaller_than_list() {
-        let mut list = LinkedList::new();
-        let mut item = ListItem::new(1);
-        list.push(&mut item);
-
-        {
-            let mut iter = IterMut::new(&mut list);
-            let item = iter.next();
-            assert_eq!(item, Some(&mut 1));
-
-            // Modify item - mutable iterator allows it
-            *(item.unwrap()) = 3;
-
-            assert_eq!(iter.next(), None);
-        }
-
-        let mut item2 = ListItem::new(2);
-        list.push(&mut item2);
-
-        let mut iter = IterMut::new(&mut list);
-        assert_eq!(iter.next(), Some(&mut 2));
-        assert_eq!(iter.next(), Some(&mut 3));
-        assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
The LinkedList ownership scheme allows only owner of an Item or owner of mutable reference to an item to modify an item. Mutable iterator allows everyone with mutable access to the LinkedList to modify any item. That's why the mutable iterator is against the ownership scheme and is removed.