### PR TITLE
Include interior mutability for Mutex

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -3,14 +3,14 @@
 //! This mutex requires proof of disabled radio IRQs provided by the `CriticalSection`'s lock
 
 use crate::crit_sect::CriticalSection;
+use core::cell::{Ref, RefCell, RefMut};
 
-/// Wraps variable which is accessible from radio IRQ
-pub struct Mutex<T> {
-    inner: T,
-}
+// TODO create Mutexes for specific IRQs, or lists of IRQs like radio + timer
+/// Wraps variable which is accessible from an IRQ
+pub struct Mutex<T>(RefCell<T>);
 
 impl<T> Mutex<T> {
-    /// Creates new wrapper for a variable accessible from radio IRQ
+    /// Creates new wrapper for a variable accessible from an IRQ
     ///
     /// # Example
     ///
@@ -20,7 +20,7 @@ impl<T> Mutex<T> {
     /// static mut ISR_CALLED: Mutex<bool> = Mutex::new(false);
     /// ```
     pub const fn new(value: T) -> Mutex<T> {
-        Self { inner: value }
+        Self(RefCell::new(value))
     }
 
     /// Borrows Mutex's internal variable with mutually exclusive access
@@ -31,23 +31,47 @@ impl<T> Mutex<T> {
     /// # #[macro_use] extern crate nrf_radio;
     /// # missing_test_fns!();
     /// # fn main() {
-    /// use core::cell::RefCell;
     /// use nrf_radio::crit_sect;
     /// use nrf_radio::mutex::Mutex;
     ///
-    /// static ISR_CALLED: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));
+    /// static ISR_READ_ONLY_DATA: Mutex<u32> = Mutex::new(15);
     ///
     /// crit_sect::locked(|cs_token| {
-    ///   *ISR_CALLED.borrow(cs_token).borrow_mut() = true;
+    ///   assert_eq!(*ISR_READ_ONLY_DATA.borrow(cs_token), 15);
     /// });
     /// # }
     /// ```
-    pub fn borrow<'cs>(&'cs self, _cs: &'cs CriticalSection) -> &'cs T {
-        &self.inner
+    pub fn borrow<'cs>(&'cs self, _cs: &'cs CriticalSection) -> Ref<'cs, T> {
+        self.0.borrow()
+    }
+
+    /// Mutably borrows Mutex's internal variable with mutually exclusive access
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # #[macro_use] extern crate nrf_radio;
+    /// # missing_test_fns!();
+    /// # fn main() {
+    /// use nrf_radio::crit_sect;
+    /// use nrf_radio::mutex::Mutex;
+    ///
+    /// static ISR_CALLED: Mutex<bool> = Mutex::new(false);
+    ///
+    /// crit_sect::locked(|cs_token| {
+    ///   *ISR_CALLED.borrow_mut(cs_token) = true;
+    /// });
+    /// # }
+    /// ```
+    pub fn borrow_mut<'cs>(&'cs self, _cs: &'cs CriticalSection) -> RefMut<'cs, T> {
+        self.0.borrow_mut()
     }
 }
 
 // Safety: Mutex is Sync assumming contained type is Send and the CriticalSection module prevents
-// concurrent access to Mutex from multiple contexts. This assumption is verified run-time if
-// RefCell is used inside the mutex
+// concurrent access to Mutex from multiple contexts. This assumption is verified run-time by
+// RefCell used inside the mutex
+// TODO: Instead of using RefCell maybe some other mechanism like AtomicBool to check if mutex is
+// being borrowed simultaneously from multiple contexts? Or checking run-time thread/handler mode
+// and finding handler mode if given IRQ is being blocked by mutex
 unsafe impl<T> Sync for Mutex<T> where T: Send {}


### PR DESCRIPTION
This patch creates interior mutability using RefCell. Possibly it will be replaced with UnsafeCell in the future when more sophisticated detection of broken critical section will be introduced in the Mutex module.

From the Mutex user perspective anything dereferenced to the type contained by mutex must be returned from borrow or borrow_mut functions. It should not make any assumptions what exact type it is.