### PR TITLE
Create TaskTrigger trait and add as dependency to Timer

### DIFF
--- a/src/hw/timer/timer_using_timer.rs
+++ b/src/hw/timer/timer_using_timer.rs
@@ -6,7 +6,7 @@
 //! for battery operated devices.
 
 use super::super::ppi::traits::Channel;
-use super::{Timer, Timestamper};
+use super::{TaskTrigger, Timer, Timestamp, Timestamper};
 use crate::error::Error;
 use core::ops::Deref;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -33,12 +33,15 @@ impl Deref for TimerPeriphWrapper {
 unsafe impl Sync for TimerPeriphWrapper {} // Is this really safe considering it's just pointer
                                            // dereference?
 
+const CAPTURE_NOW_CH: usize = 0;
 const CAPTURE_TIMESTAMP_CH: usize = 1;
+const TRIGGER_TASK_CH: usize = 2;
 
 /// Timer based on `TIMER` peripheral
 pub struct TimerUsingTimer {
     timer: TimerPeriphWrapper,
     is_capturing: AtomicBool,
+    is_triggering: AtomicBool,
 }
 
 impl TimerUsingTimer {
@@ -62,6 +65,7 @@ impl TimerUsingTimer {
         Self {
             timer: TimerPeriphWrapper::new(timer),
             is_capturing: AtomicBool::new(false),
+            is_triggering: AtomicBool::new(false),
         }
     }
 }
@@ -74,6 +78,11 @@ impl<PC: Channel> Timer<PC> for TimerUsingTimer {
         self.timer.prescaler.write(|w| w.prescaler().variant(4));
         self.timer.tasks_start.write(|w| w.tasks_start().set_bit());
         Ok(())
+    }
+
+    fn now(&self) -> Result<Timestamp, Error> {
+        self.timer.tasks_capture[CAPTURE_NOW_CH].write(|w| w.tasks_capture().set_bit());
+        Ok(self.timer.cc[CAPTURE_NOW_CH].read().bits())
     }
 }
 
@@ -98,6 +107,25 @@ impl<PC: Channel> Timestamper<PC> for TimerUsingTimer {
 
     fn timestamp(&self) -> Result<u32, Error> {
         Ok(self.timer.cc[CAPTURE_TIMESTAMP_CH].read().bits())
+    }
+}
+
+impl<PC: Channel> TaskTrigger<PC> for TimerUsingTimer {
+    fn trigger_task_at(&self, ppi_ch: &PC, time: Timestamp) -> Result<(), Error> {
+        self.is_triggering
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_or(Err(Error::WouldBlock), |_| {
+                self.timer.cc[TRIGGER_TASK_CH].write(|w| w.cc().variant(time));
+                ppi_ch.publish_by(&self.timer.events_compare[TRIGGER_TASK_CH] as *const _)
+            })
+    }
+
+    fn stop_triggering_task(&self, ppi_ch: &PC) -> Result<(), Error> {
+        self.is_triggering
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .map_or(Err(Error::WouldBlock), |_| {
+                ppi_ch.stop_publishing_by(&self.timer.events_compare[TRIGGER_TASK_CH] as *const _)
+            })
     }
 }
 
@@ -149,6 +177,24 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
+    fn test_now() {
+        let timer_mock = TimerMock::new();
+        let mut timer: TimerUsingTimer = TimerUsingTimer::new(&timer_mock);
+
+        let result = <TimerUsingTimer as Timer<MockChannel>>::start(&mut timer);
+        assert!(result.is_ok());
+
+        let expected_timestamp = 0xfdb97531;
+
+        timer_mock.cc[CAPTURE_NOW_CH].write(|w| w.cc().variant(expected_timestamp));
+
+        let result = <TimerUsingTimer as Timer<MockChannel>>::now(&timer);
+        // TODO: How to check if TASKS_CAPTURE[CAPTURE_NOW_CH] was called?
+        assert_eq!(result, Ok(expected_timestamp));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_timestamp() {
         let timer_mock = TimerMock::new();
         let timer = TimerUsingTimer::new(&timer_mock);
@@ -187,7 +233,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn test_start_twice_fails() {
+    fn test_start_capturing_twice_fails() {
         let timer_mock = TimerMock::new();
         let timer = TimerUsingTimer::new(&timer_mock);
 
@@ -291,6 +337,144 @@ mod tests {
         assert!(result.is_ok());
 
         let result = timer.stop_capturing_timestamps(&ppi_ch_mock);
+        assert_eq!(result, Err(Error::WouldBlock));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_prepare_triggering() {
+        let timer_mock = TimerMock::new();
+        let timer = TimerUsingTimer::new(&timer_mock);
+
+        let timestamp = 0x87654321;
+        let expected_event_ptr = &timer_mock.events_compare[TRIGGER_TASK_CH] as *const _ as u32;
+
+        let mut ppi_ch_mock = MockChannel::new();
+        ppi_ch_mock
+            .expect_publish_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let result = timer.trigger_task_at(&ppi_ch_mock, timestamp);
+        assert!(result.is_ok());
+
+        assert_eq!(timer_mock.cc[TRIGGER_TASK_CH].read().cc().bits(), timestamp);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_prepare_triggering_twice_fails() {
+        let timer_mock = TimerMock::new();
+        let timer = TimerUsingTimer::new(&timer_mock);
+
+        let timestamp = 0x01234567;
+        let expected_event_ptr = &timer_mock.events_compare[TRIGGER_TASK_CH] as *const _ as u32;
+
+        let mut ppi_ch_mock = MockChannel::new();
+        ppi_ch_mock
+            .expect_publish_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let result = timer.trigger_task_at(&ppi_ch_mock, timestamp);
+        assert!(result.is_ok());
+
+        let result = timer.trigger_task_at(&ppi_ch_mock, timestamp);
+        assert_eq!(result, Err(Error::WouldBlock));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_stop_triggering_fails_if_not_started() {
+        let timer_mock = TimerMock::new();
+        let timer = TimerUsingTimer::new(&timer_mock);
+
+        let ppi_ch_mock = MockChannel::new();
+
+        let result = timer.stop_triggering_task(&ppi_ch_mock);
+        assert_eq!(result, Err(Error::WouldBlock));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_stop_triggering_when_started() {
+        let timer_mock = TimerMock::new();
+        let timer = TimerUsingTimer::new(&timer_mock);
+
+        let timestamp = 0xcafecafe;
+        let expected_event_ptr = &timer_mock.events_compare[TRIGGER_TASK_CH] as *const _ as u32;
+
+        let mut ppi_ch_mock = MockChannel::new();
+        ppi_ch_mock
+            .expect_publish_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+        let result = timer.trigger_task_at(&ppi_ch_mock, timestamp);
+        assert!(result.is_ok());
+
+        ppi_ch_mock
+            .expect_stop_publishing_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+        let result = timer.stop_triggering_task(&ppi_ch_mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_stop_publishing_twice_fails() {
+        let timer_mock = TimerMock::new();
+        let timer = TimerUsingTimer::new(&timer_mock);
+
+        let timestamp = 0x01020304;
+        let expected_event_ptr = &timer_mock.events_compare[TRIGGER_TASK_CH] as *const _ as u32;
+
+        let mut ppi_ch_mock = MockChannel::new();
+        ppi_ch_mock
+            .expect_publish_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+        let result = timer.trigger_task_at(&ppi_ch_mock, timestamp);
+        assert!(result.is_ok());
+
+        ppi_ch_mock
+            .expect_stop_publishing_by()
+            .withf(
+                move |t: &*const nrf52840_hal::pac::generic::Reg<
+                    timer0::events_compare::EVENTS_COMPARE_SPEC,
+                >| *t as u32 == expected_event_ptr,
+            )
+            .times(1)
+            .returning(|_| Ok(()));
+        let result = timer.stop_triggering_task(&ppi_ch_mock);
+        assert!(result.is_ok());
+
+        let result = timer.stop_triggering_task(&ppi_ch_mock);
         assert_eq!(result, Err(Error::WouldBlock));
     }
 }


### PR DESCRIPTION
TaskTrigger is a trait for timers which shows that given timer can publish to PPI channels at specified time