### PR TITLE
Add capability to check if scheduled hw task was or will be triggered

### DIFF
--- a/src/hw/timer/mod.rs
+++ b/src/hw/timer/mod.rs
@@ -13,13 +13,12 @@ pub mod timer_using_timer;
 #[cfg(feature = "mocked_platform")]
 pub mod timer_using_timer;
 
-use super::ppi::traits::Channel;
-use crate::error::Error;
+pub mod traits;
 
 /// Absolute time (timestamp) in this system
 ///
 /// The resolution is 1 microsecond
-type Timestamp = u32;
+pub type Timestamp = u32;
 
 // TODO: so far I have no idea how to make this module portable. Let's think about it later
 //       It needs to be able to use TIMER, RTC, combination of both, or newer hardware peripherals
@@ -32,62 +31,8 @@ type Timestamp = u32;
 //       defined at the mod level. It would allow avoiding dynamic dispatch, but instead it would
 //       limits the software build to a single timer type. Would such limitation be ok?
 //
-//       Let's keep dynamic dispatch for now and come back to this decision later.
-//       Like most architecture decisions changing this will be difficult, but I don't know Rust
-//       well enough yet to take good architectural decisions now.
+//       Let's try PPI pattern to avoid dynamic dispatching especially when TriggerHandle type is
+//       introduced.
 
-/// Defines functions required by any module providing timer features
-///
-/// Modules implementing this trait are expected to use hardware, or lower level features (like
-/// operating system timers) to provide required features
-pub trait Timer<PC: Channel>: Sync + Timestamper<PC> + TaskTrigger<PC> {
-    /// Start this timer
-    ///
-    /// When timer is started its value is monotonically increasing in time.
-    fn start(&mut self) -> Result<(), Error>;
-
-    /// Get current time
-    fn now(&self) -> Result<Timestamp, Error>;
-}
-
-/// Capability of timestamping hardware events
-///
-/// The timestamps must be taken using a freerunning timer synchronized with the freeruning timers
-/// for other features of the [`Timer`] trait
-// TODO: multiple channels?
-pub trait Timestamper<PC: Channel> {
-    /// Start capturing timestamps of events published to the passed PPI channel
-    ///
-    /// When an event is published in the passed PPI channel the timestamp is to be captured. The
-    /// value of the timestamp can be checked with the [`timestamp`](Timestamper::timestamp)
-    /// function. The module keeps capturing timestamps of following events published in the PPI
-    /// channel overwritting previous timestamps until
-    /// [`stop_capturing_timestamps`](Timestamper::stop_capturing_timestamps) is called.
-    fn start_capturing_timestamps(&self, ppi_ch: &PC) -> Result<(), Error>;
-
-    /// Stop capturing timestamps of events published to the passed PPI channel
-    ///
-    /// After calling this function the last captured timestamp (if any) is available through a call
-    /// to the [`timestamp`](Timestamper::timestamp) function.
-    fn stop_capturing_timestamps(&self, ppi_ch: &PC) -> Result<(), Error>;
-
-    /// Get the last captured timestamp (if any) in microseconds
-    fn timestamp(&self) -> Result<Timestamp, Error>;
-}
-
-/// Capability of triggering hardware tasks
-///
-/// The tasks are triggered according to a freeruning timer synchronized with the freerunning
-/// timers for other features of the [`Timer`] trait
-pub trait TaskTrigger<PC: Channel> {
-    /// Prepare hardware to publish to a PPI channel at specified time
-    ///
-    /// At specified `time` this timer published to the passed PPI channel what triggers all tasks
-    /// subscribing to this channel.
-    fn trigger_task_at(&self, ppi_ch: &PC, time: Timestamp) -> Result<(), Error>;
-
-    /// Deconfigure hardware from publishing timer event to the passed PPI channel
-    fn stop_triggering_task(&self, ppi_ch: &PC) -> Result<(), Error>;
-}
-
-// TODO: callback scheduler trait
+/// Selected type of timer implementation for this build
+pub type Timer = timer_using_timer::TimerUsingTimer;

--- a/src/hw/timer/traits.rs
+++ b/src/hw/timer/traits.rs
@@ -1,0 +1,83 @@
+//! Traits required from a portable Timer object
+
+use super::Timestamp;
+use crate::error::Error;
+use crate::hw::ppi::Channel;
+
+/// Defines functions required by any module providing timer features
+///
+/// Modules implementing this trait are expected to use hardware, or lower level features (like
+/// operating system timers) to provide required features
+pub trait Timer: Sync + Timestamper + TaskTrigger {
+    /// Start this timer
+    ///
+    /// When timer is started its value is monotonically increasing in time.
+    fn start(&mut self) -> Result<(), Error>;
+
+    /// Get current time
+    fn now(&self) -> Result<Timestamp, Error>;
+
+    /// Check if the passed `timestamp` is in the past
+    fn was_timestamp_in_past(&self, timestamp: &Timestamp) -> Result<bool, Error> {
+        let now = self.now()?;
+        let one_tick_ago = Timestamp::wrapping_sub(now, 1);
+        Ok(Timestamp::wrapping_sub(one_tick_ago, *timestamp) < (Timestamp::MAX / 2))
+    }
+}
+
+/// Capability of timestamping hardware events
+///
+/// The timestamps must be taken using a freerunning timer synchronized with the freeruning timers
+/// for other features of the [`Timer`] trait
+// TODO: multiple channels?
+pub trait Timestamper {
+    /// Start capturing timestamps of events published to the passed PPI channel
+    ///
+    /// When an event is published in the passed PPI channel the timestamp is to be captured. The
+    /// value of the timestamp can be checked with the [`timestamp`](Timestamper::timestamp)
+    /// function. The module keeps capturing timestamps of following events published in the PPI
+    /// channel overwritting previous timestamps until
+    /// [`stop_capturing_timestamps`](Timestamper::stop_capturing_timestamps) is called.
+    fn start_capturing_timestamps(&self, ppi_ch: &Channel) -> Result<(), Error>;
+
+    /// Stop capturing timestamps of events published to the passed PPI channel
+    ///
+    /// After calling this function the last captured timestamp (if any) is available through a call
+    /// to the [`timestamp`](Timestamper::timestamp) function.
+    fn stop_capturing_timestamps(&self, ppi_ch: &Channel) -> Result<(), Error>;
+
+    /// Get the last captured timestamp (if any) in microseconds
+    fn timestamp(&self) -> Result<Timestamp, Error>;
+}
+
+/// Capability of triggering hardware tasks
+///
+/// The tasks are triggered according to a freeruning timer synchronized with the freerunning
+/// timers for other features of the [`Timer`] trait
+pub trait TaskTrigger {
+    /// Type representing a scheduled trigger task
+    type TriggerHandle;
+
+    /// Prepare hardware to publish to a PPI channel at specified time
+    ///
+    /// At specified `time` this timer published to the passed PPI channel what triggers all tasks
+    /// subscribing to this channel.
+    fn trigger_task_at(
+        &self,
+        ppi_ch: &Channel,
+        time: Timestamp,
+    ) -> Result<Self::TriggerHandle, Error>;
+
+    /// Deconfigure hardware from publishing timer event to the passed PPI channel
+    ///
+    /// The passed `ppi_ch` must be the same that was passed to the [`publish_task_to`] method.
+    /// The object implementing this trait does not keep reference to `ppi_ch` to avoid borrowing
+    /// it while the timer is active.
+    fn stop_triggering_task(
+        &self,
+        handle: Self::TriggerHandle,
+        ppi_ch: &Channel,
+    ) -> Result<(), Error>;
+}
+
+// TODO: callback scheduler trait


### PR DESCRIPTION
Add functions to the Timer trait to check if a scheduled hardware task was triggered, and a trait method checking if the time "was or will be triggered" - inteneded to be used to check if the task was scheduled in time or too late.