### PR TITLE
Prevent dropping ack buffer during transmission

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     NoMemory,
     /// No free resources
     NoResources,
+    /// Requested resource already taken
+    AlreadyTaken,
     /// The passed buffer cannot contain all necessary data
     TooSmallBuffer,
     /// The received frame is invalid


### PR DESCRIPTION
Rx module passed a pointer to static buffer containing ack frame when requesting transmission of the tx frame, but then it dropped the buffer. Dropped buffern can be repurposed for other needs, so there was a risk that other module could start using and overwrite the buffer containing ack being transmitted.
This patch modifies Rx module so that it keeps the buffer containing ack frame during whole ack transmission process. Then the buffer is passed to the requestor of the Rx operation. The requestor can be interested on content of the transmitted Ack frame to avoid race conditions in setting AckData